### PR TITLE
fix update config when detect changes

### DIFF
--- a/controllers/apphook_controller.go
+++ b/controllers/apphook_controller.go
@@ -265,6 +265,13 @@ func (r *AppHookReconciler) getDriverManager(instance *v1alpha1.AppHook, appSecr
 		}
 		// cache the drivermanager
 		r.AppMap[instance.Name] = mgr
+		return r.AppMap[instance.Name], nil
+	}
+
+	// check for update
+	err := r.AppMap[instance.Name].Update(instance, appSecret)
+	if err != nil {
+		return nil, err
 	}
 
 	return r.AppMap[instance.Name], nil


### PR DESCRIPTION
When CR/secret changes, apphook controller should update the db config in cache. 